### PR TITLE
We need semigroups >= 0.17 for the Proxy instance to work in prelim-monoid

### DIFF
--- a/prelim-semigroup.cabal
+++ b/prelim-semigroup.cabal
@@ -31,7 +31,7 @@ library
 
   build-depends:
                       base           >= 4     && < 5
-                    , semigroups     >= 0.8   && < 0.19
+                    , semigroups     >= 0.17  && < 0.19
                     , prelim-prelude == 0.0.1
 
   ghc-options:


### PR DESCRIPTION
Sending a PR since I don't seem to have write access to prelim yet.

Signed-off-by: Ricky Elrod <ricky@elrod.me>